### PR TITLE
Remove menu capability

### DIFF
--- a/app/javascript/components/Intake.js
+++ b/app/javascript/components/Intake.js
@@ -405,7 +405,11 @@ class Intake extends React.Component {
                   <Button>Cancel</Button>
                 </Form.Control>
                 <Form.Control>
-                  <Button onClick={this.onSubmit} className="button" color="primary" renderAs="a" href={`/menu_items/show_new?id=${this.props.id}`}>Submit</Button>
+                  {/* old menu reference */}
+                  {/* <Button onClick={this.onSubmit} className="button" color="primary" renderAs="a" href={`/menu_items/show_new?id=${this.props.id}`}>Submit</Button> */}
+                  {/* direct link to builder */}
+                  <Button onClick={this.onSubmit} className="button" color="primary" renderAs="a" href={`/builder?id=${this.props.id}`}>Submit</Button>
+
                 </Form.Control>
               </Form.Field>
             </Container>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,11 @@ Rails.application.routes.draw do
   put '/questionnaire/:id', to: 'questionnaire#update'
   get '/questionnaire/:id', to: 'questionnaire#show'
   get '/questionnaire/:id/redcap', to: 'questionnaire#redcap'
-  resources :menu_items, only: [:index, :new, :create]
-  get '/menu_items/show_new', to: 'menu_items#show_new'
+
+  # menu_items are currently not supported
+  # resources :menu_items, only: [:index, :new, :create]
+  # get '/menu_items/show_new', to: 'menu_items#show_new'
+
   # get '/questionnaire/standard', to: 'questionnaire#standard'
 
   namespace :admin do


### PR DESCRIPTION
Comments out the currently broken menu_item routes
Updates the submit link on `intake` to  bypass the menu upload page and instead go directly to `builder`