### PR TITLE
Add flash message styling

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10895,4 +10895,22 @@
    background-color: #fafafa;
    padding: 3rem 1.5rem 6rem;
  }
+
+ .alert-success {
+  background-color: #dff0d8;
+  color: #3c763d;
+  border: 1px solid #d6e9c6;
+}
+
+.alert-error {
+  background-color: #f2dede;
+  color: #a94442;
+  border: 1px solid #ebccd1;
+}
+
+.alert-notice {
+  background-color: #d9edf7;
+  color: #31708f;
+  border: 1px solid #bce8f1;
+}
  /*# sourceMappingURL=bulma.css.map */

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,17 +1,18 @@
 module Admin
   class DashboardController < ApplicationController
     def index
-      @headers = ['ID','Question group','Section','Question','Mandatory','Field Type','Choices, Calculations, OR Slider Labels','Tag1','Tag2','Variable / Field Name','Form Name','SectionHeader','Field Label','Field Note','Text Validation Type OR Show Slider Number','Text Validation Min','Text Validation Max','Identifier?','Branching Logic (Show field only if...)','Required Field?','Custom Alignment','Question Number (surveys only)','Matrix Group Name','Matrix Ranking?','Field Annotation']
+      @headers = ['ID', 'Question group', 'Section', 'Question', 'Mandatory', 'Field Type', 'Choices, Calculations, OR Slider Labels', 'Tag1', 'Tag2',
+                  'Variable / Field Name', 'Form Name', 'SectionHeader', 'Field Label', 'Field Note', 'Text Validation Type OR Show Slider Number', 'Text Validation Min', 'Text Validation Max', 'Identifier?', 'Branching Logic (Show field only if...)', 'Required Field?', 'Custom Alignment', 'Question Number (surveys only)', 'Matrix Group Name', 'Matrix Ranking?', 'Field Annotation']
     end
 
     def upload
       result = Services::CsvImporter.new(csv_contents).import!
-      if result == "success"
-        flash[:notice] = "CSV import successful!"
+      if result == 'success'
+        flash[:success] = 'CSV import successful!'
       else
-        flash[:notice] = "CSV import failed: #{result}"
+        flash[:error] = "CSV import failed: #{result}"
       end
-        redirect_to action: :index
+      redirect_to action: :index
     end
 
     def sample_csv
@@ -19,7 +20,7 @@ module Admin
         format.csv do
           response.headers['Content-Type'] = 'text/csv'
           response.headers['Content-Disposition'] = 'attachment; filename=example_questions.csv'
-          render :template => "/admin/dashboard/example_csv.csv.erb"
+          render template: '/admin/dashboard/example_csv.csv.erb'
         end
       end
     end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -2,7 +2,9 @@ module Admin
   class DashboardController < ApplicationController
     def index
       @headers = ['ID', 'Question group', 'Section', 'Question', 'Mandatory', 'Field Type', 'Choices, Calculations, OR Slider Labels', 'Tag1', 'Tag2',
-                  'Variable / Field Name', 'Form Name', 'SectionHeader', 'Field Label', 'Field Note', 'Text Validation Type OR Show Slider Number', 'Text Validation Min', 'Text Validation Max', 'Identifier?', 'Branching Logic (Show field only if...)', 'Required Field?', 'Custom Alignment', 'Question Number (surveys only)', 'Matrix Group Name', 'Matrix Ranking?', 'Field Annotation']
+                  'Variable / Field Name', 'Form Name', 'SectionHeader', 'Field Label', 'Field Note', 'Text Validation Type OR Show Slider Number',
+                  'Text Validation Min', 'Text Validation Max', 'Identifier?', 'Branching Logic (Show field only if...)', 'Required Field?',
+                  'Custom Alignment', 'Question Number (surveys only)', 'Matrix Group Name', 'Matrix Ranking?', 'Field Annotation']
     end
 
     def upload

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,4 +1,9 @@
 <div class="container">
+  <div class="container">
+    <% flash.each do |key, value| %>
+    <div class="alert alert-<%= key %>"><%= value %></div>
+    <% end %>
+  </div>
   <h1 class="title">Question Import</h1>
     <%= form_tag({action: :upload}, multipart: true, method:'post') do %>
       <div class="field">
@@ -13,11 +18,7 @@
     <% end %>
 </div>
 <br>
-<div class="container">
-  <% flash.each do |key, value| %>
-  <div class="alert alert-<%= key %>"><%= value %></div>
-  <% end %>
-</div>
+
 <div class="container">
 <h5 class="title is-5">
   Question Import Rules:


### PR DESCRIPTION
## Description

- Moves the admin dashboard flash message to top of screen
- Updates dashboard flash messages to `success` and `error` instead of generic `notice`
- Adds CSS styling to flash messages: `.alert-success`, `alert-error`, .`alert-notice`. (I don't see `notice` being used elsewhere but I included it in the css since that was the original dashboard flash message. We can pull it out if we want to keep things a little cleaner)



## Screenshots
#### Success Message:
<img width="1409" alt="Screenshot 2023-04-16 at 8 50 06 AM" src="https://user-images.githubusercontent.com/62966813/232322538-2d5bd288-60d3-4621-8049-5d423f71facb.png">

#### Error Message
<img width="1394" alt="Screenshot 2023-04-16 at 8 49 18 AM" src="https://user-images.githubusercontent.com/62966813/232322561-696fe64a-63a6-44d2-8da7-739465d92791.png">


## Issue
Closes Issue #76 