### PR TITLE
82 fix questionscontrollerdestroy

### DIFF
--- a/app/controllers/admin/dashboard/questions_controller.rb
+++ b/app/controllers/admin/dashboard/questions_controller.rb
@@ -8,13 +8,14 @@ module Admin
       def destroy
         question = Question.find(params['id'])
         if !question.children.empty?
-          flash[:error] = "Question ##{question.id} has children questions and cannot be deleted. Please remove questions with parent ##{question.id} first and then try again."
+          flash[:error] =
+            "Question ##{question.id} has children questions and cannot be deleted. Please remove questions with parent ##{question.id} first and then try again."
         else
           question.destroy!
           flash[:success] = "Successfully deleted question ##{question.id}"
         end
 
-          redirect_to admin_dashboard_questions_path
+        redirect_to admin_dashboard_questions_path
       end
 
       def nuke

--- a/app/controllers/admin/dashboard/questions_controller.rb
+++ b/app/controllers/admin/dashboard/questions_controller.rb
@@ -7,11 +7,14 @@ module Admin
 
       def destroy
         question = Question.find(params['id'])
-        question.taggings.destroy_all
-        question.questionnaires.destroy_all
-        question.destroy!
+        if !question.children.empty?
+          flash[:error] = "Question ##{question.id} has children questions and cannot be deleted. Please remove questions with parent ##{question.id} first and then try again."
+        else
+          question.destroy!
+          flash[:success] = "Successfully deleted question ##{question.id}"
+        end
 
-        redirect_to admin_dashboard_questions_path
+          redirect_to admin_dashboard_questions_path
       end
 
       def nuke

--- a/app/controllers/admin/dashboard/questions_controller.rb
+++ b/app/controllers/admin/dashboard/questions_controller.rb
@@ -7,7 +7,7 @@ module Admin
 
       def destroy
         question = Question.find(params['id'])
-        if !question.children.empty?
+        if question.children.present?
           flash[:error] =
             "Question ##{question.id} has children questions and cannot be deleted. Please remove questions with parent ##{question.id} first and then try again."
         else

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -13,7 +13,7 @@ class Question < ApplicationRecord
   has_many :questionnaire_questions
   has_many :questionnaires, through: :questionnaire_questions
 
-  belongs_to :parent, class_name: 'Question', optional: true, dependent: :destroy
+  belongs_to :parent, class_name: 'Question', optional: true
   has_many :children, class_name: 'Question', foreign_key: 'parent_id', dependent: :destroy
 
   scope :standard, -> { joins(:tags).where("tags.name = ?", "universal") }

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -7,10 +7,10 @@ class Question < ApplicationRecord
 
   store :redcap_metadata, accessors: [:variable, :form_name, :section_header, :field_label, :field_note, :text_validation_type, :text_validation_min, :text_validation_max]
 
-  has_many :taggings
+  has_many :taggings, dependent: :destroy
   has_many :tags, through: :taggings
 
-  has_many :questionnaire_questions
+  has_many :questionnaire_questions, dependent: :destroy
   has_many :questionnaires, through: :questionnaire_questions
 
   belongs_to :parent, class_name: 'Question', optional: true

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,9 +1,4 @@
 <div class="container">
-  <div class="container">
-    <% flash.each do |key, value| %>
-    <div class="alert alert-<%= key %>"><%= value %></div>
-    <% end %>
-  </div>
   <h1 class="title">Question Import</h1>
     <%= form_tag({action: :upload}, multipart: true, method:'post') do %>
       <div class="field">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,11 @@
   </head>
 
   <body>
+    <div class="container">
+      <% flash.each do |key, value| %>
+      <div class="alert alert-<%= key %>"><%= value %></div>
+      <% end %>
+    </div>
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
## Description

- Adds logic to QuestionsController#destroy to check if the question is a parent. If question is a parent, it will set a flash message and not attempt a destroy to avoid issues with the children's dependencies. If it is a child, or has no children, it will be destroyed and set a successful flash message.
- Moves the flash message container to the application.html
- Updates Question dependencies to destroy has_many records but not belongs_to records

## Screenshots
#### Success Message
<img width="1514" alt="Screenshot 2023-04-16 at 12 02 28 PM" src="https://user-images.githubusercontent.com/62966813/232332523-7d433f6e-c185-4ab5-8001-33254a69a092.png">

#### Error message
<img width="1458" alt="Screenshot 2023-04-16 at 12 03 00 PM" src="https://user-images.githubusercontent.com/62966813/232332557-1ce67de7-2094-473a-bb17-875f930d9ce3.png">


## Issue(s)
Closes #82 